### PR TITLE
Issue11 fix how to use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ typings/
 
 # next.js build output
 .next
+/.idea/
+/.npmrc

--- a/README.md
+++ b/README.md
@@ -20,14 +20,19 @@ const { namespace } = require('hello-cls')
 
 const context = namespace.initContext()
 
+// I can't get a value from the namespace if one has not been set yet
+console.log(namespace.get('beer'))
+// -> undefined
+
 // I can set a value to a given key on the namespace
-namespace.set('beer', 🍺)
+namespace.set('beer', '🍺')
 
 // I can get a value from the namespace
 console.log(namespace.get('beer'))
-// -> 🍺
+// -> '🍺'
 
-context.close()
+// close with 'true' will flush state immediately
+context.close(true)
 
 // I can't get a value from the namespace if the context is closed
 console.log(namespace.get('beer'))

--- a/lib/context.js
+++ b/lib/context.js
@@ -25,6 +25,10 @@ class Context {
    * Private: flush context and free memory allocation
    */
   _flush () {
+    this.store.clear()
+    if (this._namespace._currentContext === this) {
+      this._namespace._currentContext = null
+    }
     this.asyncIds.forEach((asyncId) => {
       this._namespace.contextsByAsyncId.delete(asyncId)
     })

--- a/tests/integration/how-to-use.specs.js
+++ b/tests/integration/how-to-use.specs.js
@@ -1,0 +1,33 @@
+/* eslint-env node, mocha */
+
+const { expect } = require('chai')
+const { namespace } = require('../../lib/cls')
+
+describe('When namespace initializes a context', () => {
+  let context
+  beforeEach(() => {
+    context = namespace.initContext()
+  })
+
+  it('then undefined should be returned when "beer" is retrieved from the namespace', () => {
+    expect(namespace.get('beer')).to.be.undefined
+  })
+
+  describe('and the value "🍺" is set for the key "beer"', () => {
+    beforeEach(() => {
+      namespace.set('beer', '🍺')
+    })
+    it('then "🍺" should be returned when "beer" is retrieved from the namespace', () => {
+      expect(namespace.get('beer')).to.equal('🍺')
+    })
+
+    describe('and then the context is closed with flush', () => {
+      beforeEach(() => {
+        context.close(true)
+      })
+      it('then undefined should be returned when "beer" is retrieved from the namespace', () => {
+        expect(namespace.get('beer')).to.be.null
+      })
+    })
+  })
+})

--- a/tests/unit/context.unit.js
+++ b/tests/unit/context.unit.js
@@ -3,43 +3,100 @@
 const { expect } = require('chai')
 const { Namespace } = require('../../lib/namespace')
 const { Context } = require('../../lib/context')
+const { describe, beforeEach, it } = require('mocha')
 
 describe('Context', () => {
+  let namespace, mockAsyncId
+
   beforeEach(() => {
-    this.namespace = new Namespace('cookie')
-    this.mockAsyncId = 1
+    namespace = new Namespace('cookie')
+    mockAsyncId = 1
   })
   describe('Static', () => {
     it(`should construct an instance`, () => {
-      const context = new Context(this.namespace, this.mockAsyncId)
-
+      const context = new Context(namespace, mockAsyncId)
       expect(context).to.be.an.instanceOf(Context)
     })
   })
 
   describe('Instance', () => {
+    let context
+
     beforeEach(() => {
-      this.context = new Context(this.namespace, this.mockAsyncId)
+      context = new Context(namespace, mockAsyncId)
     })
 
     it(`should have a private property _namespace`, () => {
-      expect(this.context).to.have.a.property('_namespace').that.equals(this.namespace)
+      expect(context).to.have.a.property('_namespace').that.equals(namespace)
     })
 
     it(`should have a public property asyncIds`, () => {
-      expect(this.context).to.have.a.property('asyncIds').that.is.an.instanceOf(Set)
-      expect(this.context.asyncIds.size).to.equal(1)
-      expect(this.context.asyncIds.has(this.mockAsyncId)).to.be.true
+      expect(context).to.have.a.property('asyncIds').that.is.an.instanceOf(Set)
+      expect(context.asyncIds.size).to.equal(1)
+      expect(context.asyncIds.has(mockAsyncId)).to.be.true
     })
 
     it(`should have a public property store`, () => {
-      expect(this.context).to.have.a.property('store').that.is.an.instanceOf(Map)
-      expect(this.context.store.size).to.equal(0)
+      expect(context).to.have.a.property('store').that.is.an.instanceOf(Map)
+      expect(context.store.size).to.equal(0)
     })
 
     it(`should have a public method close`, () => {
-      expect(this.context).to.have.a.property('close').that.is.an.instanceOf(Function)
+      expect(context).to.have.a.property('close').that.is.an.instanceOf(Function)
       // TODO: test it further
+    })
+
+    function contextClosedWithFlush () {
+      context.close(true)
+    }
+
+    describe('has values stored', () => {
+      let testName, testValue
+
+      beforeEach(() => {
+        testName = 'testName'
+        testValue = 'testValue'
+        context.store.set(testName, testValue)
+      })
+
+      describe('and is closed with flush', () => {
+        beforeEach(contextClosedWithFlush)
+
+        it(`the store map should be empty`, () => {
+          expect(context.store.size).to.equal(0)
+        })
+      })
+    })
+
+    describe('is the current context in namespace', () => {
+      beforeEach(() => {
+        namespace._currentContext = context
+      })
+
+      describe('and is closed with flush', () => {
+        beforeEach(contextClosedWithFlush)
+
+        it(`should no longer be set as current namespace context`, () => {
+          expect(namespace._currentContext).to.be.null
+        })
+      })
+    })
+
+    describe('is not the current context in namespace', () => {
+      let otherContext
+      beforeEach(() => {
+        let otherMockAsyncId = 2
+        otherContext = new Context(namespace, otherMockAsyncId)
+        namespace._currentContext = otherContext
+      })
+
+      describe('and is closed with flush', () => {
+        beforeEach(contextClosedWithFlush)
+
+        it(`the current namespace context should be the same`, () => {
+          expect(namespace._currentContext).to.equal(otherContext)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
This is a proposed solution for[ issue 11](https://github.com/hellocomet/hello-cls/issues/11) for the hello-cls library.

The objective is to correct the "how to use" example on the readme because it currently does not work.  This change corrects the example to immediately flush the context information on close.