### PR TITLE
Get rid of hack to set _currentcontext

### DIFF
--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -47,9 +47,7 @@ class Namespace {
     const asyncId = executionAsyncId()
     const context = new Context(this, asyncId)
     this.contextsByAsyncId.set(asyncId, context)
-
-    // HACK: this setTimeout helps ... don't know yet why, but without it we lost the context
-    setTimeout(() => {}, 0)
+    this._currentContext = context
     return context
   }
 

--- a/tests/integration/nested-contexts.specs.js
+++ b/tests/integration/nested-contexts.specs.js
@@ -1,0 +1,69 @@
+/* eslint-env node, mocha */
+/* eslint-disable no-unused-expressions, promise/param-names */
+
+const { expect } = require('chai')
+const { namespace } = require('../../lib/cls')
+
+const KEY = 'fruit'
+function getContextValue () {
+  return namespace.get(KEY)
+}
+function setContextValue(value) {
+  namespace.set(KEY, value)
+}
+
+describe('when nested contexts are initialized', () => {
+
+  let resolvedPromiseResultValue, promise1ContextValue, promise2ContextValue, promise3ContextValue, afterAwaitContextValue, resolvedPromiseContextValue
+  beforeEach(async () => {
+    resolvedPromiseResultValue = promise1ContextValue = promise2ContextValue = promise3ContextValue = afterAwaitContextValue = resolvedPromiseContextValue =null
+    namespace.initContext()
+    setContextValue('bananas')
+    const p1 = new Promise((r1) => {
+      promise1ContextValue = getContextValue()
+      namespace.initContext()
+      setContextValue('oranges')
+      const p2 = new Promise((r2) => {
+        promise2ContextValue = getContextValue()
+        setContextValue('apples')
+        const p3 = new Promise((r3) => {
+          promise3ContextValue = getContextValue()
+          r3(getContextValue())
+        })
+        r2(p3)
+      })
+      r1(p2)
+    }).then(result => {
+      resolvedPromiseContextValue = getContextValue()
+      resolvedPromiseResultValue = result
+      setContextValue('strawberries')
+    })
+    await p1
+    afterAwaitContextValue = getContextValue()
+  })
+
+  it('then context value at the beginning of promise 1 is "bananas"', () => {
+    expect(promise1ContextValue).to.equal('bananas')
+  })
+
+  it('then context value at the beginning of promise 2 is "oranges"', () => {
+    expect(promise2ContextValue).to.equal('oranges')
+  })
+
+  it('then context value at the beginning of promise 3 is "apples"', () => {
+    expect(promise3ContextValue).to.equal('apples')
+  })
+
+  it('then resolved promise value is "apples"', () => {
+    expect(resolvedPromiseResultValue).to.equal('apples')
+  })
+
+  it('then context value at promise 3 resolution is "bananas"', () => {
+    expect(resolvedPromiseContextValue).to.equal('bananas')
+  })
+
+  it('then context value after awaiting promise 1 resolution is "strawberries"', () => {
+    expect(afterAwaitContextValue).to.equal('strawberries')
+  })
+
+})

--- a/tests/integration/nested-contexts.specs.js
+++ b/tests/integration/nested-contexts.specs.js
@@ -2,9 +2,10 @@
 /* eslint-disable no-unused-expressions, promise/param-names */
 
 const { expect } = require('chai')
-const { namespace } = require('../../lib/cls')
+const { Namespace } = require('../../lib/cls')
 
 const KEY = 'fruit'
+let namespace
 function getContextValue () {
   return namespace.get(KEY)
 }
@@ -16,6 +17,7 @@ describe('when nested contexts are initialized', () => {
 
   let resolvedPromiseResultValue, promise1ContextValue, promise2ContextValue, promise3ContextValue, afterAwaitContextValue, resolvedPromiseContextValue
   beforeEach(async () => {
+    namespace = new Namespace('test')
     resolvedPromiseResultValue = promise1ContextValue = promise2ContextValue = promise3ContextValue = afterAwaitContextValue = resolvedPromiseContextValue =null
     namespace.initContext()
     setContextValue('bananas')

--- a/tests/unit/namespace.unit.js
+++ b/tests/unit/namespace.unit.js
@@ -82,5 +82,17 @@ describe('Namespace', () => {
       expect(this.namespace).to.have.property('initContext').that.is.an.instanceOf(Function)
       expect(returnedContext).to.be.an.instanceOf(Context)
     })
+
+    describe('when initContext is executed', () => {
+      let context
+      beforeEach(() => {
+        context = this.namespace.initContext()
+      })
+
+      it('then the resulting context should be set as currentContext', () => {
+        expect(this.namespace._currentContext).to.equal(context)
+      })
+    })
+
   })
 })


### PR DESCRIPTION
The original initContext() method contained the following statement:
```javascript
    // HACK: this setTimeout helps ... don't know yet why, but without it we lost the context
    setTimeout(() => {}, 0)
```
The comment isn't clear about what it means for the context to be "lost" but it appears that by executing setTimout() here, the code is activating the "init()" async hook.  The one thing that stands out in the init() async hook function is that it sets the "_currentContext" field to the context object associated with the asyncId, which happens to be the exact same context instance that was just create in initContext().  

This leads me to believe that when the comment say that "we lost the context", I think it means that the _currentContext does not get set without calling setTimeout().    I believe this hack can simply be replaced with a line that sets the namespace instance's _currentContext field to the context that was just created.

The purpose of this PR is to provide this recommended replacement to remove the "hack".